### PR TITLE
ci: add numpy dispatch to nanvix-ci.yml

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -206,6 +206,21 @@ jobs:
             --latest \
             release-assets/*.tar.bz2
 
+      # Trigger dependent workflows (numpy depends on OpenBLAS)
+      - name: Trigger Dependent Workflows
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+        run: |
+          RELEASE_TAG="${GITHUB_SHA::7}-nanvix-${NANVIX_SHA}"
+          echo "Triggering numpy workflow..."
+          gh api repos/nanvix/numpy/dispatches \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -f event_type="openblas-release" \
+            -f "client_payload[nanvix_sha]=${NANVIX_SHA}" \
+            -f "client_payload[openblas_tag]=${RELEASE_TAG}" || echo "::warning::Failed to trigger numpy workflow"
+
   report-failure:
     needs:
       - build


### PR DESCRIPTION
Part of the upstream CI plan (Phase 2b).

OpenBLAS is a dependency of numpy. After a successful OpenBLAS release, this dispatches an `openblas-release` event to `nanvix/numpy` so it rebuilds with the latest OpenBLAS.

See: https://github.com/nanvix/nanvix-python/blob/main/UPSTREAM-CI-PLAN.md