### PR TITLE
ci: add memory size to artifact naming convention

### DIFF
--- a/.github/workflows/nanvix-ci.yml
+++ b/.github/workflows/nanvix-ci.yml
@@ -67,15 +67,20 @@ jobs:
         include:
           - platform: hyperlight
             process-mode: multi-process
+            memory: 128mb
           - platform: hyperlight
             process-mode: single-process
+            memory: 128mb
           - platform: microvm
             process-mode: single-process
+            memory: 128mb
           - platform: microvm
             process-mode: multi-process
+            memory: 128mb
           - platform: microvm
             process-mode: standalone
-    name: ${{ matrix.platform }}-${{ matrix.process-mode }}
+            memory: 128mb
+    name: ${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
     container:
       image: nanvix/toolchain:latest-minimal
       options: --device /dev/kvm
@@ -99,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           # Find and extract the artifact matching platform and process-mode
-          ARTIFACT_PATTERN="${{ matrix.platform }}.*${{ matrix.process-mode }}.*\.tar\.bz2"
+          ARTIFACT_PATTERN="${{ matrix.platform }}.*${{ matrix.process-mode }}.*${{ matrix.memory }}.*\.tar\.bz2"
           ARTIFACT_FILE=$(find nanvix-artifacts -maxdepth 1 -type f -name "*.tar.bz2" | grep -E "$ARTIFACT_PATTERN" | head -1)
           if [[ -z "$ARTIFACT_FILE" ]]; then
             echo "::error::No ${{ matrix.platform }} ${{ matrix.process-mode }} artifact found"
@@ -137,8 +142,9 @@ jobs:
           make -f Makefile.nanvix CONFIG_NANVIX=y \
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
             PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
+            MEMORY_SIZE="${{ matrix.memory }}" \
             package
-          ARTIFACT_NAME="openblas-${{ matrix.platform }}-${{ matrix.process-mode }}"
+          ARTIFACT_NAME="openblas-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}"
           echo "ARTIFACT_TARBALL=dist/${ARTIFACT_NAME}.tar.bz2" >> "$GITHUB_ENV"
 
       - name: Verify Package
@@ -146,12 +152,13 @@ jobs:
           make -f Makefile.nanvix CONFIG_NANVIX=y \
             NANVIX_HOME="$NANVIX_HOME" NANVIX_TOOLCHAIN="/opt/nanvix" \
             PLATFORM="${{ matrix.platform }}" PROCESS_MODE="${{ matrix.process-mode }}" \
+            MEMORY_SIZE="${{ matrix.memory }}" \
             verify-package
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: openblas-${{ matrix.platform }}-${{ matrix.process-mode }}
+          name: openblas-${{ matrix.platform }}-${{ matrix.process-mode }}-${{ matrix.memory }}
           path: ${{ env.ARTIFACT_TARBALL }}
           retention-days: 7
 

--- a/Makefile.nanvix
+++ b/Makefile.nanvix
@@ -120,6 +120,7 @@ endif
 PREFIX ?= $(SYSROOT_PATH)
 PLATFORM ?= unknown
 PROCESS_MODE ?= unknown
+MEMORY_SIZE ?= unknown
 
 # OpenBLAS build options for Nanvix
 # TARGET=P2 is Pentium II (i686 compatible, no SSE required for base operations)
@@ -241,7 +242,7 @@ test: test-smoke test-integration test-functional
 
 package: all
 	@echo "=== Packaging openblas release ==="
-	$(eval ARTIFACT_NAME := openblas-$(PLATFORM)-$(PROCESS_MODE))
+	$(eval ARTIFACT_NAME := openblas-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
 	rm -rf dist/$(ARTIFACT_NAME)
 	mkdir -p dist/$(ARTIFACT_NAME)/sysroot/lib \
 	         dist/$(ARTIFACT_NAME)/sysroot/include \
@@ -262,7 +263,7 @@ package: all
 
 verify-package:
 	@echo "=== Verifying openblas package ==="
-	$(eval ARTIFACT_NAME := openblas-$(PLATFORM)-$(PROCESS_MODE))
+	$(eval ARTIFACT_NAME := openblas-$(PLATFORM)-$(PROCESS_MODE)-$(MEMORY_SIZE))
 	@TARBALL="dist/$(ARTIFACT_NAME).tar.bz2"; \
 	if [ ! -f "$$TARBALL" ]; then \
 	  echo "FAIL: Package tarball not found: $$TARBALL"; exit 1; \


### PR DESCRIPTION
## Summary

Nanvix now releases artifacts with memory size in their names. This PR updates the CI workflow and build system to use the new naming convention:

```
{name}-{platform}-{process-mode}-{memory}.tar.bz2
```

Example: `zlib-microvm-multi-process-128mb.tar.bz2`

## Changes

- Add `memory: 128mb` to all CI matrix entries
- Update `ARTIFACT_PATTERN` regex to include memory size for more specific matching
- Update `ARTIFACT_NAME` constructions to append memory suffix
- Update `upload-artifact` names to include memory
- Add `MEMORY_SIZE` variable to Makefile.nanvix (where applicable)
- Pass `MEMORY_SIZE` to `make package` and `make verify-package` calls

## Validated locally

- Build: PASS
- Smoke tests: PASS
- Package naming: Correctly produces `{name}-{platform}-{process-mode}-128mb.tar.bz2`
- Package verification: PASS
- Functional tests: PASS (on nanvixd.elf with KVM)